### PR TITLE
Fix update method for orders

### DIFF
--- a/src/main/kotlin/app/colivery/api/client/FirestoreClient.kt
+++ b/src/main/kotlin/app/colivery/api/client/FirestoreClient.kt
@@ -96,6 +96,10 @@ class FirestoreClient(private val firestore: Firestore) {
         if (firestoreOrder.driverUserId != decliderId) {
             throw BadRequestException("The driver is another person")
         }
-        orderCollection.document(orderId).set(mapOf("driver_user_id" to null, "status" to "to_be_delivered"))
+
+        orderCollection.document(orderId).set(firestoreOrder.copy(
+            driverUserId = null,
+            status = "to_be_delivered"
+        ))
     }
 }


### PR DESCRIPTION
The update method just overrode the document with a new one that only contained the two fields that should have been changed.
I've updated the method to overwrite with a full document.