### PR TITLE
Implement delete endpoint for currently logged in user

### DIFF
--- a/src/main/kotlin/app/colivery/api/api/UserResources.kt
+++ b/src/main/kotlin/app/colivery/api/api/UserResources.kt
@@ -6,14 +6,9 @@ import app.colivery.api.UserCreationDto
 import app.colivery.api.config.AuthContext
 import app.colivery.api.config.SecurityUtils
 import app.colivery.api.service.UserService
-import javax.validation.Valid
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
+import javax.validation.Valid
 
 @RestController
 @RequestMapping("/user")
@@ -47,5 +42,11 @@ class UserResources(
         val (userId) = securityUtils.principal
             ?: throw UnauthorizedException()
         return userService.findUser(userId = userId)
+    }
+
+    @DeleteMapping("/own")
+    fun deleteSelf() {
+        val userId = securityUtils.principal?.uid ?: throw UnauthorizedException()
+        this.userService.deleteUser(userId)
     }
 }

--- a/src/main/kotlin/app/colivery/api/config/FirestoreConfig.kt
+++ b/src/main/kotlin/app/colivery/api/config/FirestoreConfig.kt
@@ -21,7 +21,8 @@ const val ORDER_COLLECTION_NAME = "order"
 class FirestoreConfig {
 
     @Bean
-    fun createFirebaseApp(@Value("\${google.keyLocation:#{null}}") keyLocation: String?): FirebaseApp {
+    fun createFirebaseApp(@Value("\${google.keyLocation:#{null}}") keyLocation: String?,
+                        @Value("\${google.applicationUid:#{null}") applicationUid: String?): FirebaseApp {
         val stream = if (keyLocation == null || keyLocation == "") {
             null
         } else if (keyLocation.startsWith("classpath:")) {
@@ -37,6 +38,10 @@ class FirestoreConfig {
             options.setCredentials(GoogleCredentials.fromStream(stream))
         } else {
             options.setCredentials(GoogleCredentials.getApplicationDefault())
+        }
+
+        if (applicationUid != null) {
+            options.setDatabaseAuthVariableOverride(mapOf("uid" to applicationUid))
         }
 
         return FirebaseApp.initializeApp(options.build())

--- a/src/main/kotlin/app/colivery/api/config/FirestoreConfig.kt
+++ b/src/main/kotlin/app/colivery/api/config/FirestoreConfig.kt
@@ -4,13 +4,13 @@ import com.google.auth.oauth2.GoogleCredentials
 import com.google.cloud.firestore.Firestore
 import com.google.firebase.FirebaseApp
 import com.google.firebase.FirebaseOptions
+import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.cloud.FirestoreClient
-import java.io.FileInputStream
-import javax.validation.constraints.NotBlank
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
+import java.io.FileInputStream
 
 const val USER_COLLECTION_NAME = "user"
 const val ORDER_ITEM_COLLECTION_NAME = "items"
@@ -48,5 +48,11 @@ class FirestoreConfig {
     }
 
     @Bean
-    fun createFirestore(firebaseApp: FirebaseApp): Firestore = FirestoreClient.getFirestore(firebaseApp)
+    fun createFirestore(firebaseApp: FirebaseApp): Firestore =
+        FirestoreClient.getFirestore(firebaseApp)
+
+    @Bean
+    fun createFirebaseAuth(firebaseApp: FirebaseApp) =
+        FirebaseAuth.getInstance(firebaseApp)
+
 }

--- a/src/main/kotlin/app/colivery/api/service/UserService.kt
+++ b/src/main/kotlin/app/colivery/api/service/UserService.kt
@@ -16,4 +16,8 @@ class UserService(private val firestoreClient: FirestoreClient) {
     fun findUser(userId: String): FirestoreUser {
         return firestoreClient.findUser(userId = userId)
     }
+
+    fun deleteUser(userId: String) {
+        return firestoreClient.deleteUser(userId)
+    }
 }

--- a/src/main/resources/.gitignore
+++ b/src/main/resources/.gitignore
@@ -1,1 +1,2 @@
 serviceAccountKey.json
+application-dev.yml

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,7 +31,6 @@ security:
     - Cache-Control
   allowedPublicApis:
     - /api-docs/**
-    - /order/all
 
 springdoc:
   api-docs:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,6 +31,7 @@ security:
     - Cache-Control
   allowedPublicApis:
     - /api-docs/**
+    - /order/all
 
 springdoc:
   api-docs:


### PR DESCRIPTION
This PR adds a DELETE /user/own endpoint, which deletes the user entry in the database, the user itself from Firebase Auth and sets all orders that were created by this user to status "consumer_canceled".